### PR TITLE
Dodaj dockerfile dla API

### DIFF
--- a/API/Dockerfile
+++ b/API/Dockerfile
@@ -1,0 +1,25 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Upgrade pip
+RUN python -m pip install --upgrade pip
+
+# Copy requirements.txt and install dependencies
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+# Make port 5000 available to the world outside this container
+EXPOSE 5000
+
+# Define environment variable
+ENV FLASK_APP=app.py
+ENV FLASK_RUN_HOST=0.0.0.0
+
+# Run app.py when the container launches
+CMD ["flask", "run", "--port", "5000"]

--- a/API/app.py
+++ b/API/app.py
@@ -1,1 +1,5 @@
 from api import app
+
+if __name__ == '__main__':
+    # When developing debug can be set to True to hot reload
+    app.run(host="0.0.0.0", port=5000, debug=False)


### PR DESCRIPTION
Dodałem dockerfile w związku z #41. Ustawiłem API na port 5000, oczywiście można to szybko zmienić.

Obraz docker'a to python:3.9-slim, tu jak macie inne preferencje to będzie można zmienić.