### PR TITLE
Skonfiguruj docker-compose

### DIFF
--- a/API/Dockerfile
+++ b/API/Dockerfile
@@ -4,6 +4,12 @@ FROM python:3.9-slim
 # Set the working directory to /app
 WORKDIR /app
 
+# Install any required system packages
+RUN apt-get update && \
+    apt-get install -y gcc libpq-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy the current directory contents into the container at /app
 COPY . /app
 

--- a/API/requirements.txt
+++ b/API/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.2.3
 flask_restx==1.1.0
-SQLAlchemy==2.0.9
+Flask-SQLAlchemy==3.0.3
+psycopg2==2.9.6

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.4'
+services:
+  api:
+    build:
+      context: ./API
+      dockerfile: Dockerfile
+    container_name: api
+    ports:
+      - "5000:5000"
+    environment:
+      PYTHONUNBUFFERED: 1


### PR DESCRIPTION
PR dotyczy issue #41 

Dodałem docker-compose z zaimplementowaną usługą dla API.

W requirements zamieniałem SQLAlchemy na Flask-SQLAlchemy, ponieważ ten drugi był wymagany, a bez pierwszego działało, więc aby nie dublować pakietów zamieniłem. Jeśli jednak będą występować błędy należy przywrócić SQLAlchemy.

Dodałem również psycopg2, a on wymagał pewnych konfiguracji stąd zmiana w Dockerfile'u, gdzie dodane zostało instalowanie pakietów na systemie.

Zapraszam do przetestowania i zgłaszania jakichkolwiek uwag lub błędów.

Aby uruchomić wystarczy można na przykład użyć komendy:
`docker-compose up --build`