### PR TITLE
117-zaimplementuj-mechanizm-uwierzytelniania-uzytkownikow-w-oparciu-o-jwt-po-stronie-api

### DIFF
--- a/API/DOCS.md
+++ b/API/DOCS.md
@@ -43,3 +43,48 @@ Wybraliśmy SQLAlchemy ze względu na:
 ### Porównanie z innymi bibliotekami: SQLAlchemy vs. Psycopg2
 
 Psycopg2 to również popularna biblioteka Python, służąca do łączenia się i zarządzania bazą danych PostgreSQL. Jednak w przeciwieństwie do SQLAlchemy, Psycopg2 nie jest ORM i operuje na niższym poziomie abstrakcji, co oznacza, że programiści muszą pisać więcej kodu SQL i zarządzać strukturami danych ręcznie.
+
+## Flask-JWT-Extended
+
+Flask-JWT-Extended to rozszerzenie dla Flask, które ułatwia implementację uwierzytelniania i autoryzacji w aplikacjach internetowych. Zapewnia mechanizmy uwierzytelniania oparte na tokenach JWT (JSON Web Token).
+
+## Mechanizm uwierzytelniania użytkowników
+
+Mechanizm uwierzytelniania użytkowników opiera się o JWT (JSON Web Token). JWT to standard definiujący sposób przesyłania informacji
+pomiędzy stronami w formie obiektów JSON. Przesyłany token jest podpisany cyfrowo, co pozwala na weryfikację jego autentyczności.
+
+### Logowanie
+
+Podczas logowania, dane wprowadzone przez użytkownika sprawdzane są z danymi znajdującymi się w bazie danych. Jeśli dane są zgodne,
+zwrócony zostaje token JWT. W tokenie zapisane jest ID zalogowanego użytkownika, wykorzystywane później przy wykonywaniu różnych operacji w aplikacji (np. tworzenie nowej notatki).
+
+Po udanym logowaniu, token zwracany jest w następującym formacie:
+
+```json
+{'access_token': access_token}
+```
+
+### Rejestracja
+
+Rejestracja polega na dodaniu nowego użytkownika do bazy danych. W przypadku, gdy użytkownik o podanym adresie email już istnieje, rejestracja nie zostanie przeprowadzona. Po udanej rejestracji token JWT nie zostaje zwrócony. Logowanie musi zostać przeprowadzone osobno.
+
+### Autoryzacja
+
+Autoryzacja polega na sprawdzeniu, czy użytkownik ma uprawnienia do wykonania danej operacji. Brak tokena w nagłówku będzie
+zawsze skutkować odmową dostępu, dla każdego endpointu, który wymaga autoryzacji. W przypadku, gdy token jest obecny, sprawdzane jest czy:
+
+- token jest poprawny
+- token nie wygasł (domyślnie 1 godzina)
+- użytkownik ma uprawnienia do wykonania danej operacji (np. czy edytuje własną notatkę)
+
+Informacja o wymogu tokena dla danego endpointa znajduje się w dokumentacji Swagger. Token należy przekazać w nagłówku Authorization w formacie `Bearer <token>`, za każdym razem
+gdy następuje dostęp do chronionego endpointu.
+
+### Wygasanie tokena i wylogowanie
+
+Mechanizm wygasania tokena jest zaimplementowany w podstawowej formie. Token wygasa po upływie określonego czasu (domyślnie 1 godzina). Po wygaśnięciu tokena, użytkownik musi zalogować się ponownie, aby uzyskać nowy token. Mechanizm ten może
+zostać dodatkowo rozbudowany o tokeny odświeżąjące, które pozwalają na przedłużenie czasu ważności tokena.
+
+Nie istnieje sposób na ręczne unieważnienie wprost tokena, dlatego w aktualnej implementacji mechanizm wylogowania
+użytkownika musi polegać na usunięciu tokena z pamięci po stronie klienta (czyli stronie frontendowej). W aplikacji produkcyjnej ten mechanizm powinien być
+rozbudowany o rozwiązanie, polegające na prowadzeniu listy unieważnionych tokenów, tak by móc unieważniać tokeny również po stronie API.

--- a/API/api/__init__.py
+++ b/API/api/__init__.py
@@ -1,6 +1,8 @@
 import sys
+from datetime import timedelta
 
 from flask import Flask
+from flask_jwt_extended import JWTManager
 from flask_restx import Api
 from flask_sqlalchemy import SQLAlchemy
 
@@ -21,7 +23,22 @@ if "pytest" in sys.modules:
 else:
     app.config['SQLALCHEMY_DATABASE_URI'] = f'postgresql://{user}:{password}@{ip}/{db_name}'
 
+
+# JWT configuration
+ACCESS_EXPIRES = timedelta(hours=1)
+app.config["JWT_SECRET_KEY"] = "super-secret"
+app.config["JWT_ACCESS_TOKEN_EXPIRES"] = ACCESS_EXPIRES
+
+# This is needed to allow custom JWT error responses to be returned.
+app.config["PROPAGATE_EXCEPTIONS"] = True
+
+jwt = JWTManager(app)
+
+# Load the callback functions that handle custom JWT error responses.
+from api.utilities import auth_loaders  # noqa
+
 db = SQLAlchemy(app)
 
 from api.routes import hello  # noqa
 from api.routes import note  # noqa
+from api.routes import auth  # noqa

--- a/API/api/models/user.py
+++ b/API/api/models/user.py
@@ -1,19 +1,24 @@
 from api import db
+from api.utilities.auth import hash_password
 
 
 class UserModel(db.Model):
     __tablename__ = 'user_table'
     user_id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(100), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
     password = db.Column(db.Text, nullable=False)
     created_date = db.Column(db.DateTime, nullable=False)
+    email = db.Column(db.Text)
+    enabled = db.Column(db.Integer, default=0)
 
     def to_dict(self):
         return {
             "user_id": self.user_id,
-            "username": self.username,
+            "name": self.name,
             "password": self.password,
-            "created_date": self.created_date
+            "created_date": self.created_date,
+            "email": self.email,
+            "enabled": self.enabled
         }
 
     def save(self):
@@ -24,3 +29,6 @@ class UserModel(db.Model):
     def delete(self):
         db.session.delete(self)
         db.session.commit()
+
+    def check_password(self, password):
+        return self.password == hash_password(password)

--- a/API/api/routes/auth.py
+++ b/API/api/routes/auth.py
@@ -1,0 +1,73 @@
+import datetime
+
+from flask_jwt_extended import create_access_token
+from flask_restx import Resource, reqparse
+from sqlalchemy import or_
+
+from api import api
+from api.models.user import UserModel
+from api.utilities.auth import hash_password
+
+# Login parser
+
+login_parser = reqparse.RequestParser()
+login_parser.add_argument('email', required=True, type=str)
+login_parser.add_argument('password', required=True, type=str)
+
+# Register parser
+
+register_parser = reqparse.RequestParser()
+register_parser.add_argument(
+    'name', required=True, type=str)
+register_parser.add_argument('email', required=True, type=str)
+register_parser.add_argument(
+    'password', required=True, type=str)
+
+
+@api.route('/login')
+class Login(Resource):
+    @api.doc(description='Login endpoint')
+    @api.expect(login_parser)
+    @api.doc(params={'email': 'Email', 'password': 'Password'})
+    @api.response(200, 'Success')
+    @api.response(403, 'Forbidden')
+    def post(self):
+        args = login_parser.parse_args()
+
+        user = UserModel.query.filter_by(email=args['email']).first()
+
+        if user is None:
+            return {'message': 'Invalid email or password.'}, 403
+
+        if user.check_password(args['password']):
+            access_token = create_access_token(identity=user.user_id)
+            return {'access_token': access_token}, 200
+        else:
+            return {'message': 'Invalid email or password.'}, 403
+
+
+@api.route('/register')
+class Register(Resource):
+    @api.doc(description='Register endpoint')
+    @api.expect(register_parser)
+    @api.doc(params={'name': 'Username', 'email': 'Email', 'password': 'Password'})
+    @api.response(200, 'Success')
+    @api.response(403, 'Forbidden')
+    def post(self):
+        args = register_parser.parse_args()
+
+        user = UserModel.query.filter(
+            or_(UserModel.email == args['email'],
+                UserModel.name == args['name'])).first()
+
+        if user is not None:
+            return {'message': 'Username or email already in use.'}, 403
+
+        new_user = UserModel(
+            name=args['name'],
+            password=hash_password(args['password']),
+            email=args['email'],
+            created_date=datetime.datetime.now())
+        new_user.save()
+
+        return {'message': 'User created successfully.'}, 200

--- a/API/api/routes/note.py
+++ b/API/api/routes/note.py
@@ -1,6 +1,7 @@
 
 from time import strftime
 
+from flask_jwt_extended import get_jwt_identity, jwt_required
 from flask_restx import Resource, reqparse
 
 from api import api
@@ -10,6 +11,7 @@ from api.utilities import note as note_util
 from api.utilities import user_note as user_note_util
 from api.utilities.db_utils import (check_if_catalog_exists,
                                     check_if_user_exists)
+from api.utilities.auth import user_has_permission
 
 #
 #   Parsers
@@ -18,10 +20,11 @@ from api.utilities.db_utils import (check_if_catalog_exists,
 # Get parser
 get_parser = reqparse.RequestParser()
 get_parser.add_argument('note_id', type=int, required=True, help='Note ID')
+get_parser.add_argument('Authorization', type=str,
+                        required=True, help='Bearer token', location='headers')
 
 # Post parser
 post_parser = reqparse.RequestParser()
-post_parser.add_argument('user_id', type=int, required=True, help='User ID')
 post_parser.add_argument(
     'title', type=str, help='Note title', default='Untitled')
 post_parser.add_argument('catalog_id', type=int,
@@ -29,6 +32,8 @@ post_parser.add_argument('catalog_id', type=int,
 post_parser.add_argument('description', type=str,
                          help='Note description', default=None)
 post_parser.add_argument('body', type=str, help='Note body', default=None)
+post_parser.add_argument('Authorization', type=str,
+                         required=True, help='Bearer token', location='headers')
 
 # Put parser
 put_parser = reqparse.RequestParser()
@@ -40,10 +45,14 @@ put_parser.add_argument('catalog_id', type=int,
 put_parser.add_argument('description', type=str,
                         help='Note description')
 put_parser.add_argument('body', type=str, help='Note body')
+put_parser.add_argument('Authorization', type=str,
+                        required=True, help='Bearer token', location='headers')
 
 # Delete parser
 delete_parser = reqparse.RequestParser()
 delete_parser.add_argument('note_id', type=int, required=True, help='Note ID')
+delete_parser.add_argument('Authorization', type=str,
+                           required=True, help='Bearer token', location='headers')
 
 
 @api.route('/note')
@@ -51,13 +60,27 @@ delete_parser.add_argument('note_id', type=int, required=True, help='Note ID')
 class Note(Resource):
     @api.expect(get_parser)
     @api.doc(description='Gets a note by its ID.')
-    @api.doc(responses={404: 'Note not found.', 200: 'Success.'})
+    @api.doc(responses={404: 'Note not found.',
+                        200: 'Success.',
+                        401: 'Unauthorized.',
+                        422: 'Invalid token.',
+                        403: 'Forbidden.'})
+    @jwt_required()
     def get(self):
+        user_id = get_jwt_identity()
+
         args = get_parser.parse_args()
         note_id = args['note_id']
 
+        # The error messages should be more vague and shouldn't reveal if
+        # the note or user exists. However for our purposes this is fine, as
+        # it helps with debugging.
+
         if not note_util.check_if_note_exists(note_id):
             return {"message": "Note not found."}, 404
+
+        if not user_has_permission(user_id, note_id):
+            return {"message": "Forbidden."}, 403
 
         note = note_util.get_note_by_id(note_id)
 
@@ -69,11 +92,15 @@ class Note(Resource):
     @api.doc(description='Creates a note and its associated user_note.')
     @api.doc(responses={404: 'User or catalog not found.',
                         400: 'Bad request.',
-                        201: 'Success.'})
+                        201: 'Success.',
+                        401: 'Unauthorized.',
+                        422: 'Invalid token.'})
+    @jwt_required()
     def post(self):
         args = post_parser.parse_args()
+        user_id = get_jwt_identity()
 
-        if check_if_user_exists(args['user_id']) is False:
+        if check_if_user_exists(user_id) is False:
             return {"message": "User not found."}, 404
         elif (args['catalog_id'] is not None and
               check_if_catalog_exists(args['catalog_id']) is False):
@@ -91,7 +118,7 @@ class Note(Resource):
         note_id = note.save()
 
         user_note = UserNoteModel(
-            user_id=args['user_id'],
+            user_id=user_id,
             note_id=note_id
         )
 
@@ -103,12 +130,18 @@ class Note(Resource):
     @api.doc(description='Updates a note.')
     @api.doc(responses={404: 'Note or catalog not found.',
                         400: 'Bad request.',
-                        200: 'Success.'})
+                        200: 'Success.',
+                        401: 'Unauthorized.',
+                        422: 'Invalid token.',
+                        403: 'Forbidden.'})
+    @jwt_required()
     def put(self):
         args = put_parser.parse_args()
         args = {k: v for k, v in args.items() if v is not None}
 
-        if len(args) == 1:
+        user_id = get_jwt_identity()
+
+        if len(args) == 2 and 'note_id' in args and 'Authorization' in args:
             return {"message": "No data to update."}, 400
 
         if not note_util.check_if_note_exists(args['note_id']):
@@ -116,6 +149,9 @@ class Note(Resource):
 
         if 'catalog_id' in args and not check_if_catalog_exists(args['catalog_id']):
             return {"message": "Catalog not found."}, 404
+
+        if not user_has_permission(user_id, args['note_id']):
+            return {"message": "Forbidden."}, 403
 
         note = note_util.get_note_by_id(args['note_id'])
 
@@ -128,13 +164,22 @@ class Note(Resource):
 
     @api.expect(delete_parser)
     @api.doc(description='Deletes a note and its associated user_note.')
-    @api.doc(responses={404: 'Note not found.', 200: 'Success.'})
+    @api.doc(responses={404: 'Note not found.',
+                        200: 'Success.',
+                        401: 'Unauthorized.',
+                        422: 'Invalid token.',
+                        403: 'Forbidden.'})
+    @jwt_required()
     def delete(self):
         args = delete_parser.parse_args()
         note_id = args['note_id']
+        user_id = get_jwt_identity()
 
         if not note_util.check_if_note_exists(note_id):
             return {"message": "Note not found."}, 404
+
+        if not user_has_permission(user_id, note_id):
+            return {"message": "Forbidden."}, 403
 
         note = note_util.get_note_by_id(note_id)
         user_note = user_note_util.get_user_note_by_note_id(note_id)

--- a/API/api/utilities/auth.py
+++ b/API/api/utilities/auth.py
@@ -1,0 +1,20 @@
+from api.models.user_note import UserNoteModel
+
+
+def user_has_permission(user_id, note_id):
+    if user_id is None or note_id is None:
+        return False
+
+    user_note = UserNoteModel.query.filter_by(
+        user_id=user_id, note_id=note_id).first()
+
+    if user_note is None:
+        return False
+
+    return True
+
+
+def hash_password(password):
+    # TODO: Implement password hashing
+
+    return password

--- a/API/api/utilities/auth_loaders.py
+++ b/API/api/utilities/auth_loaders.py
@@ -1,0 +1,16 @@
+from api import jwt
+
+
+@jwt.unauthorized_loader
+def unauthorized_response(reason):
+    return {'message': 'Missing authorization header.'}, 401
+
+
+@jwt.expired_token_loader
+def expired_token_response(jwt_header, jwt_payload):
+    return {'message': 'Token has expired.'}, 401
+
+
+@jwt.invalid_token_loader
+def invalid_token_response(reason):
+    return {'message': 'Invalid token.'}, 422

--- a/API/requirements.txt
+++ b/API/requirements.txt
@@ -3,3 +3,4 @@ flask_restx==1.1.0
 Flask-SQLAlchemy==3.0.3
 psycopg2==2.9.6
 pytest==7.3.1
+Flask-JWT-Extended==4.4.4

--- a/API/tests/conftest.py
+++ b/API/tests/conftest.py
@@ -16,8 +16,8 @@ def app():
     # Initial setup
     with app.app_context():
         db.create_all()
-        UserModel(username="test_user", password="test_pass",
-                  created_date="2021-01-01").save()
+        UserModel(name="test_user", password="test_pass",
+                  created_date="2021-01-01", email="test_email").save()
         NoteModel(title="test_title", description="test_description",
                   body="test_body", created_date="2021-01-01",
                   updated_date="2021-01-01").save()

--- a/API/tests/test_auth.py
+++ b/API/tests/test_auth.py
@@ -1,0 +1,83 @@
+import json
+from api.models.user import UserModel
+
+
+def test_login(client):
+    response = client.post(
+        '/login',
+        data=json.dumps({
+            'email': 'test_email',
+            'password': 'test_pass'
+        }),
+        content_type='application/json'
+    )
+
+    assert response.status_code == 200
+    assert 'access_token' in response.json
+
+
+def test_login_403(client):
+    response = client.post(
+        '/login',
+        data=json.dumps({
+            'email': 'test_email',
+            'password': 'wrong_pass'
+        }),
+        content_type='application/json'
+    )
+
+    assert response.status_code == 403
+    assert 'access_token' not in response.json
+    assert response.json['message'] == 'Invalid email or password.'
+
+
+def test_login_403_no_user(client):
+    response = client.post(
+        '/login',
+        data=json.dumps({
+            'email': 'wrong_email',
+            'password': 'test_pass'
+        }),
+        content_type='application/json'
+    )
+
+    assert response.status_code == 403
+    assert 'access_token' not in response.json
+    assert response.json['message'] == 'Invalid email or password.'
+
+
+def test_register(client):
+    response = client.post(
+        '/register',
+        data=json.dumps({
+            'name': 'test_user2',
+            'email': 'test_email2',
+            'password': 'test_pass2'
+        }),
+        content_type='application/json'
+    )
+
+    assert response.status_code == 200
+    assert response.json['message'] == 'User created successfully.'
+
+    with client.application.app_context():
+        user = UserModel.query.filter_by(email='test_email2').first()
+        assert user is not None
+        assert user.name == 'test_user2'
+        assert user.email == 'test_email2'
+        assert user.check_password('test_pass2') is True
+
+
+def test_register_403(client):
+    response = client.post(
+        '/register',
+        data=json.dumps({
+            'name': 'test_user',
+            'email': 'test_email',
+            'password': 'test_pass'
+        }),
+        content_type='application/json'
+    )
+
+    assert response.status_code == 403
+    assert response.json['message'] == 'Username or email already in use.'

--- a/API/tests/test_auth_utils.py
+++ b/API/tests/test_auth_utils.py
@@ -1,0 +1,14 @@
+from api.utilities.auth import user_has_permission, hash_password
+
+
+def test_user_has_permission(client):
+    with client.application.app_context():
+        assert user_has_permission(1, 1) is True
+        assert user_has_permission(1, 2) is False
+        assert user_has_permission(2, 1) is False
+        assert user_has_permission(None, 1) is False
+        assert user_has_permission(1, None) is False
+
+
+def test_hash_password(client):
+    assert hash_password('test_pass') == 'test_pass'

--- a/API/tests/test_note.py
+++ b/API/tests/test_note.py
@@ -1,13 +1,17 @@
 import json
+from flask_jwt_extended import create_access_token
+from datetime import timedelta
+import time
 
 
 def test_post(client):
+    with client.application.app_context():
+        token = create_access_token(identity=1)
+
     response = client.post(
         '/note',
-        data=json.dumps(dict(
-            user_id=1,
-        )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
     assert response.status_code == 201
     assert response.json == {"note_id": 2}
@@ -18,6 +22,7 @@ def test_post(client):
             note_id=2,
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
 
     assert response.status_code == 200
@@ -25,12 +30,16 @@ def test_post(client):
 
 
 def test_get(client):
+    with client.application.app_context():
+        token = create_access_token(identity=1)
+
     response = client.get(
         '/note',
         data=json.dumps(dict(
             note_id=1,
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
     assert response.status_code == 200
     assert response.json == {"note_id": 1, "title": "test_title",
@@ -42,6 +51,9 @@ def test_get(client):
 
 
 def test_put(client):
+    with client.application.app_context():
+        token = create_access_token(identity=1)
+
     response = client.put(
         '/note',
         data=json.dumps(dict(
@@ -52,6 +64,7 @@ def test_put(client):
             catalog_id=None
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
     assert response.status_code == 200
     assert response.json == {"message": "Note updated."}
@@ -62,6 +75,7 @@ def test_put(client):
             note_id=1,
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
 
     assert response.status_code == 200
@@ -74,12 +88,16 @@ def test_put(client):
 
 
 def test_delete(client):
+    with client.application.app_context():
+        token = create_access_token(identity=1)
+
     response = client.delete(
         '/note',
         data=json.dumps(dict(
             note_id=1,
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
     assert response.status_code == 200
     assert response.json == {"message": "Note deleted."}
@@ -90,6 +108,7 @@ def test_delete(client):
             note_id=1,
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
 
     assert response.status_code == 404
@@ -97,24 +116,30 @@ def test_delete(client):
 
 
 def test_get_404(client):
+    with client.application.app_context():
+        token = create_access_token(identity=1)
+
     response = client.get(
         '/note',
         data=json.dumps(dict(
             note_id=100,
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
     assert response.status_code == 404
     assert response.json == {"message": "Note not found."}
 
 
 def test_post_404(client):
+    with client.application.app_context():
+        token = create_access_token(identity=1)
+        invalid_user_token = create_access_token(identity=100)
+
     response = client.post(
         '/note',
-        data=json.dumps(dict(
-            user_id=100,
-        )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {invalid_user_token}'}
     )
     assert response.status_code == 404
     assert response.json == {"message": "User not found."}
@@ -126,36 +151,32 @@ def test_post_404(client):
             catalog_id=100
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
     assert response.status_code == 404
     assert response.json == {"message": "Catalog not found."}
 
 
-def test_post_400(client):
-    response = client.post(
-        '/note',
-        data=json.dumps(dict(
-            user_id="abc",
-        )),
-        content_type='application/json',
-    )
-
-    assert response.status_code == 400
-
-
 def test_delete_404(client):
+    with client.application.app_context():
+        token = create_access_token(identity=1)
+
     response = client.delete(
         '/note',
         data=json.dumps(dict(
             note_id=100,
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
     assert response.status_code == 404
     assert response.json == {"message": "Note not found."}
 
 
 def test_put_404(client):
+    with client.application.app_context():
+        token = create_access_token(identity=1)
+
     response = client.put(
         '/note',
         data=json.dumps(dict(
@@ -166,6 +187,7 @@ def test_put_404(client):
             catalog_id=None
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
 
     assert response.status_code == 404
@@ -181,6 +203,7 @@ def test_put_404(client):
             body="updated body",
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
 
     assert response.status_code == 404
@@ -188,6 +211,9 @@ def test_put_404(client):
 
 
 def test_put_400(client):
+    with client.application.app_context():
+        token = create_access_token(identity=1)
+
     response = client.put(
         '/note',
         data=json.dumps(dict(
@@ -198,6 +224,7 @@ def test_put_400(client):
             catalog_id=None
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
 
     assert response.status_code == 400
@@ -208,7 +235,215 @@ def test_put_400(client):
             note_id=1,
         )),
         content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
     )
 
     assert response.status_code == 400
     assert response.json == {"message": "No data to update."}
+
+
+def test_get_401(client):
+    response = client.get(
+        '/note',
+        data=json.dumps(dict(
+            note_id=1,
+        )),
+        content_type='application/json',
+    )
+    assert response.status_code == 401
+    assert response.json == {"message": "Missing authorization header."}
+
+
+def test_get_422(client):
+    response = client.get(
+        '/note',
+        data=json.dumps(dict(
+            note_id=1,
+        )),
+        content_type='application/json',
+        headers={'Authorization': 'Bearer abc'}
+    )
+    assert response.status_code == 422
+    assert response.json == {"message": "Invalid token."}
+
+
+def test_get_403(client):
+    with client.application.app_context():
+        token = create_access_token(identity=2)
+
+    response = client.get(
+        '/note',
+        data=json.dumps(dict(
+            note_id=1,
+        )),
+        content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 403
+    assert response.json == {"message": "Forbidden."}
+
+
+def test_get_401_expired(client):
+    with client.application.app_context():
+        token = create_access_token(
+            identity=1, expires_delta=timedelta(microseconds=1))
+
+    # Sleep for 2 microseconds to ensure the token has expired.
+    time.sleep(0.000002)
+
+    response = client.get(
+        '/note',
+        data=json.dumps(dict(
+            note_id=1,
+        )),
+        content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 401
+    assert response.json == {"message": "Token has expired."}
+
+
+def test_post_401(client):
+    response = client.post(
+        '/note',
+        content_type='application/json',
+    )
+    assert response.status_code == 401
+    assert response.json == {"message": "Missing authorization header."}
+
+
+def test_post_422(client):
+    response = client.post(
+        '/note',
+        content_type='application/json',
+        headers={'Authorization': 'Bearer abc'}
+    )
+    assert response.status_code == 422
+    assert response.json == {"message": "Invalid token."}
+
+
+def test_post_401_expired(client):
+    with client.application.app_context():
+        token = create_access_token(
+            identity=1, expires_delta=timedelta(microseconds=1))
+
+    time.sleep(0.000002)
+
+    response = client.post(
+        '/note',
+        content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 401
+    assert response.json == {"message": "Token has expired."}
+
+
+def test_put_401(client):
+    response = client.put(
+        '/note',
+        content_type='application/json',
+    )
+    assert response.status_code == 401
+    assert response.json == {"message": "Missing authorization header."}
+
+
+def test_put_401_expired(client):
+    with client.application.app_context():
+        token = create_access_token(
+            identity=1, expires_delta=timedelta(microseconds=1))
+
+    time.sleep(0.000002)
+
+    response = client.put(
+        '/note',
+        content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 401
+    assert response.json == {"message": "Token has expired."}
+
+
+def test_put_422(client):
+    response = client.put(
+        '/note',
+        content_type='application/json',
+        headers={'Authorization': 'Bearer abc'}
+    )
+
+    assert response.status_code == 422
+    assert response.json == {"message": "Invalid token."}
+
+
+def test_put_403(client):
+    with client.application.app_context():
+        token = create_access_token(identity=2)
+
+    response = client.put(
+        '/note',
+        data=json.dumps(dict(
+            note_id=1,
+            title="updated title",
+        )),
+        content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 403
+    assert response.json == {"message": "Forbidden."}
+
+
+def test_delete_401(client):
+    response = client.delete(
+        '/note',
+        content_type='application/json',
+    )
+    assert response.status_code == 401
+    assert response.json == {"message": "Missing authorization header."}
+
+
+def test_delete_401_expired(client):
+    with client.application.app_context():
+        token = create_access_token(
+            identity=1, expires_delta=timedelta(microseconds=1))
+
+    time.sleep(0.000002)
+
+    response = client.delete(
+        '/note',
+        content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 401
+    assert response.json == {"message": "Token has expired."}
+
+
+def test_delete_422(client):
+    response = client.delete(
+        '/note',
+        content_type='application/json',
+        headers={'Authorization': 'Bearer abc'}
+    )
+
+    assert response.status_code == 422
+    assert response.json == {"message": "Invalid token."}
+
+
+def test_delete_403(client):
+    with client.application.app_context():
+        token = create_access_token(identity=2)
+
+    response = client.delete(
+        '/note',
+        data=json.dumps(dict(
+            note_id=1,
+        )),
+        content_type='application/json',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 403
+    assert response.json == {"message": "Forbidden."}

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Wybór  ten  podyktowany  jest  kilkoma  istotnymi  zaletami, które  sprawiają
 }
 ```
 
+## Uwierzytelnianie użytkowników
+
+Uwierzytelnianie użytkowników odbywa się za pomocą tokenów JWT (JSON Web Token). Tokeny te są generowane przez API i przesyłane do klienta, który używa ich do autoryzacji
+operacji wymagających uwierzytelnienia. Dokładny opis mechanizmu uwierzytelniania znajduje się w [dokumentacji API](
+  https://github.com/Tomasz-Zdeb/Software-Engineering-Class-Project/blob/master/API/DOCS.md
+).
+
 ## Model kolaboracji
 
 ### Definiowanie zadań : **Backlog**

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ Wybór  ten  podyktowany  jest  kilkoma  istotnymi  zaletami, które  sprawiają
 
 ## Uwierzytelnianie użytkowników
 
-Uwierzytelnianie użytkowników odbywa się za pomocą tokenów JWT (JSON Web Token). Tokeny te są generowane przez API i przesyłane do klienta, który używa ich do autoryzacji
-operacji wymagających uwierzytelnienia. Dokładny opis mechanizmu uwierzytelniania znajduje się w [dokumentacji API](
+Uwierzytelnianie użytkowników odbywa się za pomocą tokenów JWT (JSON Web Token). Tokeny te są generowane przez API i przesyłane do klienta, który używa ich do autoryzacji operacji wymagających uwierzytelnienia. Dokładny opis mechanizmu uwierzytelniania znajduje się w [dokumentacji API](
   https://github.com/Tomasz-Zdeb/Software-Engineering-Class-Project/blob/master/API/DOCS.md
 ).
 


### PR DESCRIPTION
Dodałem mechanizm logowania, rejestracji, a także sprawdzania uprawnień użytkownika do danych endpointów. Postaram się w osobnym PRze zamieścić w późniejszym czasie dokumentację nowo dodanej biblioteki.

Głowną zmianą są dwa nowe endpointy, login i register, odpowiedzialne za weryfikację i rejestrowanie nowych użytkowników. Przy logowaniu tworzony jest token, z którego odczytać można id zalogowanego użytkownika. Na jego podstawie sprawdzane jest czy dany użytkownik jest właścicielem wybranej notatki, a więc czy ma prawo do edytowania jej. Przy tworzeniu notatki od teraz wykorzystywane jest id z tokenu, więc nie trzeba przekazywać go w requeście POST. Token do api przekazywany jest w headerze `Authorization` w formie `Bearer <token>`. Do pozostałych endpointów (endpointów note) dodałem dodatkowe kody operacji związane z autoryzacją użytkowników, np. 401 lub 403, sygnalizujące głównie odmowę dostępu. 

W aplikacji produkcyjnej według mnie wypadałoby nie zwracać kodu 403 jako informacji, że niezalogowany użytkownik nie może uzyskać dostępu np. do danej notatki (i uogólnić komunikaty np. o nieistnieniu danej notatki), ponieważ taka odpowiedź potwierdza istnienie danego zasobu, co w niektórych przypadkach może stanowić jakieś zagrożenie i ułatwić wykorzystywanie podatności. W naszym przypadku jednak takie informacje mogą przyspieszać debugowanie i nie stanowią żadnego zagrożenia, dlatego myślę, że nie ma sensu się obecnie nad tym pochylać.

![obraz](https://github.com/Tomasz-Zdeb/Software-Engineering-Class-Project/assets/66798628/594ef876-7ea8-4e85-a6ee-14e93508878b)
