### PR TITLE
130-Popraw-endpoint-/register 

### DIFF
--- a/API/api/routes/auth.py
+++ b/API/api/routes/auth.py
@@ -31,8 +31,14 @@ class Login(Resource):
     @api.doc(params={'email': 'Email', 'password': 'Password'})
     @api.response(200, 'Success')
     @api.response(403, 'Forbidden')
+    @api.response(400, 'Bad request')
     def post(self):
         args = login_parser.parse_args()
+
+        if not all(args.values()) or \
+                not len(args['email'].rstrip()) or \
+                not len(args['password'].rstrip()):
+            return {'message': 'Username, email and password required.'}, 400
 
         user = UserModel.query.filter_by(email=args['email']).first()
 
@@ -53,8 +59,15 @@ class Register(Resource):
     @api.doc(params={'name': 'Username', 'email': 'Email', 'password': 'Password'})
     @api.response(200, 'Success')
     @api.response(403, 'Forbidden')
+    @api.response(400, 'Bad request')
     def post(self):
         args = register_parser.parse_args()
+
+        if not all(args.values()) or \
+                not len(args['name'].rstrip()) or \
+                not len(args['email'].rstrip()) or \
+                not len(args['password'].rstrip()):
+            return {'message': 'Username, email and password required.'}, 400
 
         user = UserModel.query.filter(
             or_(UserModel.email == args['email'],

--- a/API/tests/test_auth.py
+++ b/API/tests/test_auth.py
@@ -16,6 +16,81 @@ def test_login(client):
     assert 'access_token' in response.json
 
 
+def test_login_400_no_password(client):
+    response = client.post(
+        '/login',
+        data=json.dumps({
+            'email': 'test_email',
+            'password': ''
+        }),
+        content_type='application/json'
+    )
+
+    assert response.status_code == 400
+    assert 'access_token' not in response.json
+    assert response.json['message'] == 'Username, email and password required.'
+
+
+def test_login_400_no_email(client):
+    response = client.post(
+        '/login',
+        data=json.dumps({
+            'email': '',
+            'password': 'test_pass'
+        }),
+        content_type='application/json'
+    )
+
+    assert response.status_code == 400
+    assert 'access_token' not in response.json
+    assert response.json['message'] == 'Username, email and password required.'
+
+
+def test_register_400_no_name(client):
+    response = client.post(
+        '/register',
+        data=json.dumps({
+            'name': '',
+            'email': 'test_email2',
+            'password': 'test_pass2'
+        }),
+        content_type='application/json'
+    )
+
+    assert response.status_code == 400
+    assert response.json['message'] == 'Username, email and password required.'
+
+
+def test_register_400_no_email(client):
+    response = client.post(
+        '/register',
+        data=json.dumps({
+            'name': 'test_user2',
+            'email': '',
+            'password': 'test_pass2'
+        }),
+        content_type='application/json'
+    )
+
+    assert response.status_code == 400
+    assert response.json['message'] == 'Username, email and password required.'
+
+
+def test_register_400_no_password(client):
+    response = client.post(
+        '/register',
+        data=json.dumps({
+            'name': 'test_user2',
+            'email': 'test_email2',
+            'password': ''
+        }),
+        content_type='application/json'
+    )
+
+    assert response.status_code == 400
+    assert response.json['message'] == 'Username, email and password required.'
+
+
 def test_login_403(client):
     response = client.post(
         '/login',


### PR DESCRIPTION
Poprawia przeoczenie związane z brakiem walidacji czy hasło, mail i nazwa nie są puste dla endpointu /register i /login.

closes #130 